### PR TITLE
Update 1104. Sum of Number Segments.cpp

### DIFF
--- a/PAT/Advanced Level/1104. Sum of Number Segments.cpp
+++ b/PAT/Advanced Level/1104. Sum of Number Segments.cpp
@@ -6,11 +6,12 @@ int main() {
     cin.tie(0);
     gg ni;
     cin >> ni;
-    double s = 0.0, ai;
+    gg s = 0;
+    double ai;
     for (gg i = 0; i < ni; ++i) {
         cin >> ai;
-        s += (i + 1) * (ni - i) * ai;
+        s += (gg)(ai * 1000) * (i + 1) * (ni - i);
     }
-    cout << fixed << setprecision(2) << s;
+    cout << fixed << setprecision(2) << (s / 1000.0);
     return 0;
 }


### PR DESCRIPTION
由于 PAT 测试用例更改，原来的答案无法通过第三个测试点，如图
![@J5PT)@ IWLL342728_(~TK](https://user-images.githubusercontent.com/86681329/168416118-565b2c51-305a-449d-a833-3e6a99bbc75a.png)
原因是N比较大时，double类型的值多次累加导致的精度误差，具体可参考这篇博客
https://www.liuchuo.net/archives/1921
修改后的解法，将double 转化为确定精度的 long long，可以避免误差。 